### PR TITLE
added data modeling for API and Security Operator roles

### DIFF
--- a/src/main/protobuf/v1/relationship.proto
+++ b/src/main/protobuf/v1/relationship.proto
@@ -28,7 +28,8 @@ message PartyRelationshipIdV1 {
   enum PartyRoleV1 {
     Delegate = 0;
     Manager = 1;
-    Operator = 2;
+    APIOperator = 2;
+    SecurityOperator = 3;
   }
 }
 

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -561,7 +561,6 @@ components:
           enum:
             - Manager
             - Delegate
-            - Operator
             - APIOperator
             - SecurityOperator
         status:

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/model/party/PartyRelationship.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/model/party/PartyRelationship.scala
@@ -20,7 +20,6 @@ object PartyRelationship {
       start = OffsetDateTime.now(),
       end = None,
       status = role match {
-        case Operator         => Active
         case APIOperator      => Active
         case SecurityOperator => Active
         case _                => Pending

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/model/party/PartyRole.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/model/party/PartyRole.scala
@@ -8,7 +8,6 @@ sealed trait PartyRole {
   def stringify: String = this match {
     case Manager          => "Manager"
     case Delegate         => "Delegate"
-    case Operator         => "Operator"
     case APIOperator      => "APIOperator"
     case SecurityOperator => "SecurityOperator"
   }
@@ -16,7 +15,6 @@ sealed trait PartyRole {
 
 case object Delegate         extends PartyRole
 case object Manager          extends PartyRole
-case object Operator         extends PartyRole
 case object APIOperator      extends PartyRole
 case object SecurityOperator extends PartyRole
 
@@ -29,7 +27,6 @@ object PartyRole extends DefaultJsonProtocol {
     override def write(obj: PartyRole): JsValue = obj match {
       case Manager          => JsString("Manager")
       case Delegate         => JsString("Delegate")
-      case Operator         => JsString("Operator")
       case APIOperator      => JsString("APIOperator")
       case SecurityOperator => JsString("SecurityOperator")
     }
@@ -39,7 +36,6 @@ object PartyRole extends DefaultJsonProtocol {
         val res: Try[PartyRole] = s match {
           case "Manager"          => Success(Manager)
           case "Delegate"         => Success(Delegate)
-          case "Operator"         => Success(Operator)
           case "APIOperator"      => Success(APIOperator)
           case "SecurityOperator" => Success(SecurityOperator)
           case _                  => Failure(new RuntimeException("Invalid token status"))
@@ -54,7 +50,6 @@ object PartyRole extends DefaultJsonProtocol {
   def fromText(str: String): Either[Throwable, PartyRole] = str match {
     case "Manager"          => Right(Manager)
     case "Delegate"         => Right(Delegate)
-    case "Operator"         => Right(Operator)
     case "APIOperator"      => Right(APIOperator)
     case "SecurityOperator" => Right(SecurityOperator)
     case _                  => Left(new RuntimeException("Invalid PartyRole")) //TODO meaningful error


### PR DESCRIPTION
This adds two new entries to the sealed trait `PartyRole`:

- APIOperator
- SecurityOperator

So far, these have been modeled as subtypes of `PartyRole`. Would you advice of making those two subtypes of `Operator` entry instead?