### PR TITLE
BlobStorage connection changed with connectionString

### DIFF
--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/service/impl/BlobStorageManagerImpl.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/partymanagement/service/impl/BlobStorageManagerImpl.scala
@@ -3,7 +3,6 @@ package it.pagopa.pdnd.interop.uservice.partymanagement.service.impl
 import akka.http.scaladsl.server.directives.FileInfo
 import com.azure.storage.blob.specialized.BlockBlobClient
 import com.azure.storage.blob.{BlobClient, BlobServiceClient, BlobServiceClientBuilder}
-import com.azure.storage.common.StorageSharedKeyCredential
 import it.pagopa.pdnd.interop.uservice.partymanagement.common.system.ApplicationConfiguration.storageAccountInfo
 import it.pagopa.pdnd.interop.uservice.partymanagement.service.{FileManager, OnboardingFilePath}
 
@@ -15,13 +14,13 @@ import scala.util.Try
 final class BlobStorageManagerImpl extends FileManager {
 
   lazy val azureBlobClient = {
-    val accountName: String = storageAccountInfo.applicationId
-    val accountKey: String  = storageAccountInfo.applicationSecret
-    val endpoint: String    = storageAccountInfo.endpoint
-    val credential          = new StorageSharedKeyCredential(accountName, accountKey)
+    val accountName: String    = storageAccountInfo.applicationId
+    val accountKey: String     = storageAccountInfo.applicationSecret
+    val endpointSuffix: String = storageAccountInfo.endpoint
+    val connectionString =
+      s"DefaultEndpointsProtocol=https;AccountName=$accountName;AccountKey=$accountKey;EndpointSuffix=$endpointSuffix"
     val storageClient: BlobServiceClient =
-      new BlobServiceClientBuilder().endpoint(endpoint).credential(credential).buildClient
-
+      new BlobServiceClientBuilder().connectionString(connectionString).buildClient()
     storageClient
   }
 


### PR DESCRIPTION
This changes the BlobStorage login according to the provided credentials.  
Few considerations hereafter.  

The actual connection string should work without interpolation, since the Azure standard, by their documentation, should expect it as a single environment variable. However, since we need both S3 and Azure support here, probably we need an agnostic mechanism for storage credentials configuration settings.

What's your point on this? Is this approach through interpolation a valid alternative? Any proposal?
