### PR TITLE
storing products map inside institutionParty

### DIFF
--- a/src/main/protobuf/v1/party.proto
+++ b/src/main/protobuf/v1/party.proto
@@ -2,6 +2,8 @@ syntax = "proto2";
 
 import "scalapb/scalapb.proto";
 
+import "v1/relationship.proto";
+
 option (scalapb.options) = {
   package_name: "it.pagopa.interop.partymanagement.model.persistence.serializer.v1"
   no_default_values_in_constructor : true
@@ -31,13 +33,20 @@ message InstitutionPartyV1 {
   repeated InstitutionAttributeV1 attributes = 8;
   required string address = 9;
   required string zipCode = 10;
-  optional string origin = 11;
+  required string origin = 11;
   optional string institutionType = 12;
-  optional string originId = 13;
+  required string originId = 13;
+  repeated InstitutionProductV1 products = 14;
 }
 
 message InstitutionAttributeV1 {
   required string origin = 1;
   required string code = 2;
   required string description = 3;
+}
+
+message InstitutionProductV1 {
+  required string product = 1;
+  required BillingV1 billing = 2;
+  optional string pricingPlan = 3;
 }

--- a/src/main/protobuf/v1/relationship.proto
+++ b/src/main/protobuf/v1/relationship.proto
@@ -51,7 +51,8 @@ message InstitutionUpdateV1 {
   optional string description = 2;
   optional string digitalAddress = 3;
   optional string address = 4;
-  optional string taxCode = 5;
+  optional string zipCode = 5;
+  optional string taxCode = 6;
 }
 
 message BillingV1 {

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -820,12 +820,6 @@ components:
         taxCode:
           description: institution tax code
           type: string
-        products:
-          type: array
-          items:
-            type: string
-            description: product names associated to this institution
-          uniqueItems: true
         origin:
           type: string
           description: The origin form which the institution has been retrieved
@@ -836,6 +830,11 @@ components:
           example: PA
         attributes:
           $ref: '#/components/schemas/Attributes'
+        products:
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/InstitutionProduct'
+          description: Institution products info
       required:
         - externalId
         - originId
@@ -845,7 +844,6 @@ components:
         - zipCode
         - taxCode
         - attributes
-        - products
         - origin
       additionalProperties: false
     Institution:
@@ -887,6 +885,11 @@ components:
           type: string
           description: institution type
           example: PA
+        products:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/InstitutionProduct'
+            description: Institution products info
         attributes:
           $ref: '#/components/schemas/Attributes'
       required:
@@ -900,6 +903,7 @@ components:
         - taxCode
         - attributes
         - origin
+        - products
       additionalProperties: false
     BulkInstitutions:
       type: object
@@ -1254,6 +1258,20 @@ components:
         - vatNumber
         - recipientCode
       additionalProperties: false
+    InstitutionProduct:
+      type: object
+      properties:
+        product:
+          type: string
+        pricingPlan:
+          type: string
+          description: pricing plan
+        billing:
+          $ref: '#/components/schemas/Billing'
+      additionalProperties: false
+      required:
+        - product
+        - billing
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -1239,6 +1239,9 @@ components:
         address:
           example: via del campo
           type: string
+        zipCode:
+          example: 20100
+          type: string
         taxCode:
           description: institution tax code
           type: string

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
@@ -226,8 +226,8 @@ class PublicApiServiceImpl(
       val productId          = relationship.product.id
       val institutionProduct = institutionParty.products
         .find(_.product == productId)
-        .getOrElse(PersistedInstitutionProduct(product = productId, pricingPlan = None, billing = null))
-        .copy(pricingPlan = relationship.pricingPlan, billing = billing)
+        .map(_.copy(pricingPlan = relationship.pricingPlan, billing = billing))
+        .getOrElse(PersistedInstitutionProduct(product = productId, pricingPlan = relationship.pricingPlan, billing = billing))
       institutionParty.copy(products = institutionParty.products.filter(_.product != productId) + institutionProduct)
     }
   }

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
@@ -189,49 +189,46 @@ class PublicApiServiceImpl(
     institutionParty: InstitutionParty,
     relationship: PersistedPartyRelationship
   ): Future[StatusReply[Party]] = {
-    val institutionPartyUpdate = updateWithInstitutionUpdate(institutionParty, relationship)
+    val institutionPartyUpdate  = updateWithInstitutionUpdate(institutionParty, relationship)
     val institutionPartyProduct = updateWithInstitutionProductInfo(institutionPartyUpdate, relationship)
-    Option.when(relationship.institutionUpdate.isDefined || relationship.billing.isDefined){
-      getCommander(institutionPartyProduct.id.toString).ask(ref => UpdateParty(institutionPartyProduct, ref))
-    }.getOrElse(Future.successful(StatusReply.Success[Party](institutionParty)))
+    Option
+      .when(relationship.institutionUpdate.isDefined || relationship.billing.isDefined) {
+        getCommander(institutionPartyProduct.id.toString).ask(ref => UpdateParty(institutionPartyProduct, ref))
+      }
+      .getOrElse(Future.successful(StatusReply.Success[Party](institutionParty)))
   }
 
   private def updateWithInstitutionUpdate(
-     institutionParty: InstitutionParty,
-     relationship: PersistedPartyRelationship
-   ): InstitutionParty = {
-    relationship.institutionUpdate.fold(institutionParty) {
-      institutionUpdate =>
-        if (institutionParty.origin == ipaOrigin)
-          institutionParty
-            .copy(institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType))
-        else
-          institutionParty.copy(
-            institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
-            address = institutionUpdate.address.getOrElse(institutionParty.address),
-            taxCode = institutionUpdate.taxCode.getOrElse(institutionParty.taxCode),
-            description = institutionUpdate.description.getOrElse(institutionParty.description),
-            digitalAddress = institutionUpdate.digitalAddress.getOrElse(institutionParty.digitalAddress)
-          )
+    institutionParty: InstitutionParty,
+    relationship: PersistedPartyRelationship
+  ): InstitutionParty = {
+    relationship.institutionUpdate.fold(institutionParty) { institutionUpdate =>
+      if (institutionParty.origin == ipaOrigin)
+        institutionParty
+          .copy(institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType))
+      else
+        institutionParty.copy(
+          institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
+          address = institutionUpdate.address.getOrElse(institutionParty.address),
+          taxCode = institutionUpdate.taxCode.getOrElse(institutionParty.taxCode),
+          description = institutionUpdate.description.getOrElse(institutionParty.description),
+          digitalAddress = institutionUpdate.digitalAddress.getOrElse(institutionParty.digitalAddress),
+          zipCode = institutionUpdate.zipCode.getOrElse(institutionParty.zipCode)
+        )
     }
   }
 
   private def updateWithInstitutionProductInfo(
-     institutionParty: InstitutionParty,
-     relationship: PersistedPartyRelationship
-   ): InstitutionParty = {
-    relationship.billing.fold(institutionParty) {
-      billing =>
-        val productId = relationship.product.id
-        val institutionProduct = institutionParty.products
-          .find(_.product == productId).getOrElse(PersistedInstitutionProduct(product=productId, pricingPlan = None, billing = null))
-          .copy(
-            pricingPlan = relationship.pricingPlan,
-            billing = billing
-          )
-        institutionParty.copy(
-          products = institutionParty.products.filter(_.product != productId) + institutionProduct
-        )
+    institutionParty: InstitutionParty,
+    relationship: PersistedPartyRelationship
+  ): InstitutionParty = {
+    relationship.billing.fold(institutionParty) { billing =>
+      val productId          = relationship.product.id
+      val institutionProduct = institutionParty.products
+        .find(_.product == productId)
+        .getOrElse(PersistedInstitutionProduct(product = productId, pricingPlan = None, billing = null))
+        .copy(pricingPlan = relationship.pricingPlan, billing = billing)
+      institutionParty.copy(products = institutionParty.products.filter(_.product != productId) + institutionProduct)
     }
   }
 

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
@@ -189,24 +189,49 @@ class PublicApiServiceImpl(
     institutionParty: InstitutionParty,
     relationship: PersistedPartyRelationship
   ): Future[StatusReply[Party]] = {
-    relationship.institutionUpdate.fold(Future.successful(StatusReply.Success[Party](institutionParty))) {
+    val institutionPartyUpdate = updateWithInstitutionUpdate(institutionParty, relationship)
+    val institutionPartyProduct = updateWithInstitutionProductInfo(institutionPartyUpdate, relationship)
+    Option.when(relationship.institutionUpdate.isDefined || relationship.billing.isDefined){
+      getCommander(institutionPartyProduct.id.toString).ask(ref => UpdateParty(institutionPartyProduct, ref))
+    }.getOrElse(Future.successful(StatusReply.Success[Party](institutionParty)))
+  }
+
+  private def updateWithInstitutionUpdate(
+     institutionParty: InstitutionParty,
+     relationship: PersistedPartyRelationship
+   ): InstitutionParty = {
+    relationship.institutionUpdate.fold(institutionParty) {
       institutionUpdate =>
-        val party: Party =
-          if (institutionParty.origin == ipaOrigin)
-            institutionParty
-              .copy(institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType))
-          else
-            institutionParty.copy(
-              institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
-              address = institutionUpdate.address.getOrElse(institutionParty.address),
-              taxCode = institutionUpdate.taxCode.getOrElse(institutionParty.taxCode),
-              description = institutionUpdate.description.getOrElse(institutionParty.description),
-              digitalAddress = institutionUpdate.digitalAddress.getOrElse(institutionParty.digitalAddress)
-            )
-
-        getCommander(party.id.toString).ask(ref => UpdateParty(party, ref))
+        if (institutionParty.origin == ipaOrigin)
+          institutionParty
+            .copy(institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType))
+        else
+          institutionParty.copy(
+            institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
+            address = institutionUpdate.address.getOrElse(institutionParty.address),
+            taxCode = institutionUpdate.taxCode.getOrElse(institutionParty.taxCode),
+            description = institutionUpdate.description.getOrElse(institutionParty.description),
+            digitalAddress = institutionUpdate.digitalAddress.getOrElse(institutionParty.digitalAddress)
+          )
     }
+  }
 
+  private def updateWithInstitutionProductInfo(
+     institutionParty: InstitutionParty,
+     relationship: PersistedPartyRelationship
+   ): InstitutionParty = {
+    relationship.billing.fold(institutionParty) {
+      billing =>
+        val institutionProduct = institutionParty.products
+          .find(_.product == relationship.product.id).getOrElse(PersistedInstitutionProduct(product=relationship.product.id, pricingPlan = None, billing = null))
+          .copy(
+            pricingPlan = relationship.pricingPlan,
+            billing = billing
+          )
+        institutionParty.copy(
+          products = institutionParty.products + institutionProduct
+        )
+    }
   }
 
   /** Code: 200, Message: successful operation, DataType: TokenInfo

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
@@ -222,14 +222,15 @@ class PublicApiServiceImpl(
    ): InstitutionParty = {
     relationship.billing.fold(institutionParty) {
       billing =>
+        val productId = relationship.product.id
         val institutionProduct = institutionParty.products
-          .find(_.product == relationship.product.id).getOrElse(PersistedInstitutionProduct(product=relationship.product.id, pricingPlan = None, billing = null))
+          .find(_.product == productId).getOrElse(PersistedInstitutionProduct(product=productId, pricingPlan = None, billing = null))
           .copy(
             pricingPlan = relationship.pricingPlan,
             billing = billing
           )
         institutionParty.copy(
-          products = institutionParty.products + institutionProduct
+          products = institutionParty.products.filter(_.product != productId) + institutionProduct
         )
     }
   }

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
@@ -9,7 +9,7 @@ import spray.json.{DefaultJsonProtocol, RootJsonFormat}
 
 package object impl extends SprayJsonSupport with DefaultJsonProtocol {
 
-  implicit val institutionUpdateFormat: RootJsonFormat[InstitutionUpdate]             = jsonFormat5(InstitutionUpdate)
+  implicit val institutionUpdateFormat: RootJsonFormat[InstitutionUpdate]             = jsonFormat6(InstitutionUpdate)
   implicit val billingFormat: RootJsonFormat[Billing]                                 = jsonFormat3(Billing)
   implicit val institutionProductFormat: RootJsonFormat[InstitutionProduct]           = jsonFormat3(InstitutionProduct)
   implicit val attributeFormat: RootJsonFormat[Attribute]                             = jsonFormat3(Attribute)

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
@@ -11,11 +11,12 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val institutionUpdateFormat: RootJsonFormat[InstitutionUpdate]             = jsonFormat5(InstitutionUpdate)
   implicit val billingFormat: RootJsonFormat[Billing]                                 = jsonFormat3(Billing)
+  implicit val institutionProductFormat: RootJsonFormat[InstitutionProduct]           = jsonFormat3(InstitutionProduct)
   implicit val attributeFormat: RootJsonFormat[Attribute]                             = jsonFormat3(Attribute)
   implicit val personSeedFormat: RootJsonFormat[PersonSeed]                           = jsonFormat1(PersonSeed)
   implicit val personFormat: RootJsonFormat[Person]                                   = jsonFormat1(Person)
   implicit val institutionSeedFormat: RootJsonFormat[InstitutionSeed]                 = jsonFormat11(InstitutionSeed)
-  implicit val institutionFormat: RootJsonFormat[Institution]                         = jsonFormat11(Institution)
+  implicit val institutionFormat: RootJsonFormat[Institution]                         = jsonFormat12(Institution)
   implicit val relationshipProductFormat: RootJsonFormat[RelationshipProduct]         = jsonFormat3(RelationshipProduct)
   implicit val relationshipFormat: RootJsonFormat[Relationship]                       = jsonFormat15(Relationship)
   implicit val relationshipProductSeedFormat: RootJsonFormat[RelationshipProductSeed] = jsonFormat2(

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/Party.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/Party.scala
@@ -48,7 +48,8 @@ object Party {
             zipCode = institutionParty.zipCode,
             origin = institutionParty.origin,
             institutionType = institutionParty.institutionType,
-            attributes = institutionParty.attributes.map(InstitutionAttribute.toApi).toSeq
+            attributes = institutionParty.attributes.map(InstitutionAttribute.toApi).toSeq,
+            products = (institutionParty.products map { p => p.product -> PersistedInstitutionProduct.toApi(p) }).toMap
           )
         )
     }
@@ -80,7 +81,8 @@ final case class InstitutionParty(
   institutionType: Option[String],
   start: OffsetDateTime,
   end: Option[OffsetDateTime],
-  attributes: Set[InstitutionAttribute]
+  attributes: Set[InstitutionAttribute],
+  products: Set[PersistedInstitutionProduct]
 ) extends Party
 
 object InstitutionParty {
@@ -102,7 +104,10 @@ object InstitutionParty {
       institutionType = institution.institutionType,
       attributes = institution.attributes.map(InstitutionAttribute.fromApi).toSet,
       start = offsetDateTimeSupplier.get,
-      end = None
+      end = None,
+      products = institution.products.fold(Set.empty[PersistedInstitutionProduct])(
+        _.values.map(PersistedInstitutionProduct.fromApi).toSet
+      )
     )
   }
 
@@ -122,7 +127,8 @@ object InstitutionParty {
       institutionType = institution.institutionType,
       start = start,
       end = end,
-      attributes = institution.attributes.map(InstitutionAttribute.fromApi).toSet
+      attributes = institution.attributes.map(InstitutionAttribute.fromApi).toSet,
+      products = institution.products.values.map(PersistedInstitutionProduct.fromApi).toSet
     )
 
 }

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedBilling.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedBilling.scala
@@ -3,7 +3,7 @@ package it.pagopa.interop.partymanagement.model.party
 import it.pagopa.interop.partymanagement.model.Billing
 
 final case class PersistedBilling(vatNumber: String, recipientCode: String, publicServices: Option[Boolean]) {
-  def toInstitutionUpdate: Billing =
+  def toBilling: Billing =
     Billing(vatNumber = vatNumber, recipientCode = recipientCode, publicServices = publicServices)
 }
 

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionProduct.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionProduct.scala
@@ -1,0 +1,21 @@
+package it.pagopa.interop.partymanagement.model.party
+
+import it.pagopa.interop.partymanagement.model.InstitutionProduct
+
+final case class PersistedInstitutionProduct(
+  product: String,
+  pricingPlan: Option[String] = None,
+  billing: PersistedBilling
+)
+
+object PersistedInstitutionProduct {
+  def toApi(p: PersistedInstitutionProduct): InstitutionProduct =
+    InstitutionProduct(product = p.product, pricingPlan = p.pricingPlan, billing = p.billing.toBilling)
+
+  def fromApi(p: InstitutionProduct): PersistedInstitutionProduct =
+    PersistedInstitutionProduct(
+      product = p.product,
+      pricingPlan = p.pricingPlan,
+      billing = PersistedBilling.fromBilling(p.billing)
+    )
+}

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionUpdate.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionUpdate.scala
@@ -7,6 +7,7 @@ final case class PersistedInstitutionUpdate(
   description: Option[String],
   digitalAddress: Option[String],
   address: Option[String],
+  zipCode: Option[String],
   taxCode: Option[String]
 ) {
   def toInstitutionUpdate: InstitutionUpdate = InstitutionUpdate(
@@ -14,6 +15,7 @@ final case class PersistedInstitutionUpdate(
     description = description,
     digitalAddress = digitalAddress,
     address = address,
+    zipCode = zipCode,
     taxCode = taxCode
   )
 }
@@ -25,6 +27,7 @@ object PersistedInstitutionUpdate {
       description = institutionUpdate.description,
       digitalAddress = institutionUpdate.digitalAddress,
       address = institutionUpdate.address,
+      zipCode = institutionUpdate.zipCode,
       taxCode = institutionUpdate.taxCode
     )
 }

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedPartyRelationship.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedPartyRelationship.scala
@@ -39,7 +39,7 @@ final case class PersistedPartyRelationship(
     tokenId = onboardingTokenId,
     pricingPlan = pricingPlan,
     institutionUpdate = institutionUpdate.map(i => i.toInstitutionUpdate),
-    billing = billing.map(b => b.toInstitutionUpdate),
+    billing = billing.map(b => b.toBilling),
     createdAt = createdAt,
     updatedAt = updatedAt
   )

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/serializer/v1/utils.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/serializer/v1/utils.scala
@@ -152,6 +152,7 @@ object utils {
           institutionType = i.institutionType,
           description = i.description,
           digitalAddress = i.digitalAddress,
+          zipCode = i.zipCode,
           address = i.address,
           taxCode = i.taxCode
         )
@@ -188,6 +189,7 @@ object utils {
           description = i.description,
           digitalAddress = i.digitalAddress,
           address = i.address,
+          zipCode = i.zipCode,
           taxCode = i.taxCode
         )
       ),

--- a/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsPartyApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsPartyApiServiceData.scala
@@ -33,7 +33,7 @@ object InstitutionsPartyApiServiceData {
     address = "address1",
     zipCode = "zipCode1",
     taxCode = "taxCode",
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     attributes = Seq.empty,
     origin = "IPA",
     institutionType = Option("PA")
@@ -47,7 +47,15 @@ object InstitutionsPartyApiServiceData {
       address = "address2",
       zipCode = "zipCode2",
       taxCode = "taxCode",
-      products = Set.empty,
+      products = Option(
+        Map(
+          "p1" -> InstitutionProduct(
+            product = "p1",
+            pricingPlan = Option("pricingPlan"),
+            billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = Option(false))
+          )
+        )
+      ),
       attributes = Seq.empty,
       origin = "IPA",
       institutionType = Option("PA")
@@ -61,7 +69,20 @@ object InstitutionsPartyApiServiceData {
       address = "address3",
       zipCode = "zipCode3",
       taxCode = "taxCode",
-      products = Set.empty,
+      products = Option(
+        Map(
+          "p1" -> InstitutionProduct(
+            product = "p1",
+            pricingPlan = Option("pricingPlan"),
+            billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = Option(false))
+          ),
+          "p2" -> InstitutionProduct(
+            product = "p2",
+            pricingPlan = Option("pricingPlan2"),
+            billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(true))
+          )
+        )
+      ),
       attributes = Seq.empty,
       origin = "IPA",
       institutionType = Option("PA")
@@ -75,7 +96,7 @@ object InstitutionsPartyApiServiceData {
       address = "address4",
       zipCode = "zipCode4",
       taxCode = "taxCode",
-      products = Set.empty,
+      products = Option(Map.empty[String, InstitutionProduct]),
       attributes = Seq.empty,
       origin = "IPA",
       institutionType = Option("PA")
@@ -92,7 +113,8 @@ object InstitutionsPartyApiServiceData {
     id = institutionUuid1,
     attributes = Seq.empty,
     origin = "IPA",
-    institutionType = Option("PA")
+    institutionType = Option("PA"),
+    products = Map.empty
   )
 
   lazy final val expected3 = Institution(
@@ -106,7 +128,19 @@ object InstitutionsPartyApiServiceData {
     id = institutionUuid3,
     attributes = Seq.empty,
     origin = "IPA",
-    institutionType = Option("PA")
+    institutionType = Option("PA"),
+    products = Map(
+      "p1" -> InstitutionProduct(
+        product = "p1",
+        pricingPlan = Option("pricingPlan"),
+        billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = Option(false))
+      ),
+      "p2" -> InstitutionProduct(
+        product = "p2",
+        pricingPlan = Option("pricingPlan2"),
+        billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(true))
+      )
+    )
   )
 
   def prepareTest(

--- a/src/test/scala/it/pagopa/interop/partymanagement/PartyApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/PartyApiServiceSpec.scala
@@ -472,7 +472,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -525,7 +525,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
         address = "address",
         zipCode = "zipCode",
         taxCode = "taxCode",
-        products = Set.empty,
+        products = Option(Map.empty[String, InstitutionProduct]),
         attributes = Seq.empty,
         origin = "IPA",
         institutionType = Option("PA")
@@ -623,7 +623,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -673,7 +673,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -779,7 +779,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -894,7 +894,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1006,7 +1006,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1095,7 +1095,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1197,7 +1197,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1287,7 +1287,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1358,7 +1358,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1461,7 +1461,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -1580,7 +1580,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")
@@ -2048,7 +2048,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
           address = "address",
           zipCode = "zipCode",
           taxCode = "taxCode",
-          products = Set.empty,
+          products = Option(Map.empty[String, InstitutionProduct]),
           attributes = Seq.empty,
           origin = "IPA",
           institutionType = Option("PA")

--- a/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
@@ -79,7 +79,7 @@ object TokenApiServiceData {
     zipCode = "zipCode1",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -92,7 +92,7 @@ object TokenApiServiceData {
     zipCode = "zipCode2",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -105,7 +105,7 @@ object TokenApiServiceData {
     zipCode = "zipCode3",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -118,7 +118,7 @@ object TokenApiServiceData {
     zipCode = "zipCode4",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -131,7 +131,7 @@ object TokenApiServiceData {
     zipCode = "zipCode4",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -144,7 +144,7 @@ object TokenApiServiceData {
     zipCode = "zipCode5",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )
@@ -157,7 +157,7 @@ object TokenApiServiceData {
     zipCode = "zipCode6",
     taxCode = "taxCode",
     attributes = Seq.empty,
-    products = Set.empty,
+    products = Option(Map.empty[String, InstitutionProduct]),
     origin = "IPA",
     institutionType = Option("PA")
   )

--- a/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
@@ -30,6 +30,7 @@ object TokenApiServiceData {
   lazy final val tokenId5 = UUID.randomUUID()
   lazy final val tokenId6 = UUID.randomUUID()
   lazy final val tokenId7 = UUID.randomUUID()
+  lazy final val tokenId8 = UUID.randomUUID()
 
   lazy final val personId1 = UUID.randomUUID()
   lazy final val personId2 = UUID.randomUUID()
@@ -46,6 +47,7 @@ object TokenApiServiceData {
   lazy final val orgId5 = UUID.randomUUID()
   lazy final val orgId6 = UUID.randomUUID()
   lazy final val orgId7 = UUID.randomUUID()
+  lazy final val orgId8 = UUID.randomUUID()
 
   lazy final val personSeed1 = PersonSeed(id = personId1)
   lazy final val personSeed2 = PersonSeed(id = personId2)
@@ -69,6 +71,8 @@ object TokenApiServiceData {
   lazy final val originId6   = "origin_id16"
   lazy final val externalId7 = "ext_id17"
   lazy final val originId7   = "origin_id17"
+  lazy final val externalId8 = "ext_id18"
+  lazy final val originId8   = "origin_id18"
 
   lazy final val institutionSeed1 = InstitutionSeed(
     externalId = externalId1,
@@ -161,11 +165,39 @@ object TokenApiServiceData {
     origin = "IPA",
     institutionType = Option("PA")
   )
+  lazy final val institutionSeed8 = InstitutionSeed(
+    externalId = externalId8,
+    originId = originId8,
+    description = "Institutions Eighteen",
+    digitalAddress = "mail18@mail.org",
+    address = "address8",
+    zipCode = "zipCode8",
+    taxCode = "taxCode",
+    attributes = Seq.empty,
+    products = Option(
+      Map(
+        "p1" -> InstitutionProduct(
+          product = "p1",
+          pricingPlan = Option("pricingPlan"),
+          billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = None)
+        ),
+        "p2" -> InstitutionProduct(
+          product = "p2",
+          pricingPlan = Option("pricingPlan2"),
+          billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(false))
+        )
+      )
+    ),
+    origin = "DUMMY",
+    institutionType = None
+  )
 
   // format: off
   lazy final val relationshipSeed2 = RelationshipSeed(from = personId1, to = orgId1, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed1 = RelationshipSeed(from = personId1, to = orgId1, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
-  lazy final val relationshipSeed3 = RelationshipSeed(from = personId2, to = orgId2, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
+  lazy final val relationshipSeed3 = RelationshipSeed(from = personId2, to = orgId2, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"),
+    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"))),
+    pricingPlan = Option("OVERRIDE_pricingPlan"), billing = Option(Billing(vatNumber="OVERRIDE_vatNumber", recipientCode="OVERRIDE_recipientCode", publicServices=Option(true))))
   lazy final val relationshipSeed4 = RelationshipSeed(from = personId2, to = orgId2, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed5 = RelationshipSeed(from = personId3, to = orgId3, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed6 = RelationshipSeed(from = personId3, to = orgId3, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
@@ -177,6 +209,10 @@ object TokenApiServiceData {
   lazy final val relationshipSeed12 = RelationshipSeed(from = personId6, to = orgId6, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed13 = RelationshipSeed(from = personId7, to = orgId7, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed14 = RelationshipSeed(from = personId7, to = orgId7, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
+  lazy final val relationshipSeed15 = RelationshipSeed(from = personId2, to = orgId8, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"),
+    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"))),
+    pricingPlan = Option("OVERRIDE_pricingPlan"), billing = Option(Billing(vatNumber="OVERRIDE_vatNumber", recipientCode="OVERRIDE_recipientCode", publicServices=Option(true))))
+  lazy final val relationshipSeed16 = RelationshipSeed(from = personId2, to = orgId8, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
 
   lazy final val relationship1 = Relationship(id = UUID.randomUUID(), from = personId2, to = orgId2, role = PartyRole.MANAGER,  product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
   lazy final val relationship2 = Relationship(id = UUID.randomUUID(), from = personId2, to = orgId2, role = PartyRole.DELEGATE, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
@@ -190,6 +226,8 @@ object TokenApiServiceData {
   lazy final val relationship10 = Relationship(id = UUID.randomUUID(), from = personId6, to = orgId6, role = PartyRole.DELEGATE, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
   lazy final val relationship11 = Relationship(id = UUID.randomUUID(), from = personId7, to = orgId7, role = PartyRole.MANAGER, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
   lazy final val relationship12 = Relationship(id = UUID.randomUUID(), from = personId7, to = orgId7, role = PartyRole.DELEGATE, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
+  lazy final val relationship15 = Relationship(id = UUID.randomUUID(), from = personId2, to = orgId8, role = PartyRole.MANAGER, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
+  lazy final val relationship16 = Relationship(id = UUID.randomUUID(), from = personId2, to = orgId8, role = PartyRole.DELEGATE, product = RelationshipProduct(id = "p1", role ="admin", createdAt = OffsetDateTime.now()), fileName = None, contentType = None, state = RelationshipState.PENDING, createdAt = OffsetDateTime.now(), updatedAt = None)
 
   lazy final val relationshipId1 = UUID.randomUUID()
   lazy final val relationshipId2 = UUID.randomUUID()
@@ -203,6 +241,8 @@ object TokenApiServiceData {
   lazy final val relationshipId10 = UUID.randomUUID()
   lazy final val relationshipId11 = UUID.randomUUID()
   lazy final val relationshipId12 = UUID.randomUUID()
+  lazy final val relationshipId15 = UUID.randomUUID()
+  lazy final val relationshipId16 = UUID.randomUUID()
 
   lazy final val partyRelationship1 = PersistedPartyRelationship(id = relationshipId1, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId2, to = orgId2, role = PersistedPartyRole.Manager,  product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
   lazy final val partyRelationship2 = PersistedPartyRelationship(id = relationshipId2, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId2, to = orgId2, role = PersistedPartyRole.Delegate, product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
@@ -216,6 +256,8 @@ object TokenApiServiceData {
   lazy final val partyRelationship10 = PersistedPartyRelationship(id = relationshipId10, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId6, to = orgId6, role = PersistedPartyRole.Delegate, product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
   lazy final val partyRelationship11 = PersistedPartyRelationship(id = relationshipId11, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId7, to = orgId7, role = PersistedPartyRole.Manager, product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
   lazy final val partyRelationship12 = PersistedPartyRelationship(id = relationshipId12, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId7, to = orgId7, role = PersistedPartyRole.Delegate, product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
+  lazy final val partyRelationship15 = PersistedPartyRelationship(id = relationshipId15, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId2, to = orgId8, role = PersistedPartyRole.Manager,  product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
+  lazy final val partyRelationship16 = PersistedPartyRelationship(id = relationshipId16, createdAt = OffsetDateTime.now(), updatedAt = None, state = Pending, from = personId2, to = orgId8, role = PersistedPartyRole.Delegate, product = PersistedProduct(id = "p1", role = "admin", createdAt = OffsetDateTime.now() ), filePath = None, fileName = None, contentType = None, onboardingTokenId = None, pricingPlan = None, institutionUpdate = None, billing = None)
 
   lazy val tokenSeed1: TokenSeed = TokenSeed(id = tokenId2.toString, relationships = Relationships(Seq(relationship1, relationship2)), "checksum", OnboardingContractInfo("test", "test"))
   lazy val tokenSeed2: TokenSeed = TokenSeed(id = tokenId3.toString, relationships = Relationships(Seq(relationship3, relationship4)), "checksum", OnboardingContractInfo("test", "test"))
@@ -223,6 +265,7 @@ object TokenApiServiceData {
   lazy val tokenSeed4: TokenSeed = TokenSeed(id = tokenId5.toString, relationships = Relationships(Seq(relationship7, relationship8)), "checksum", OnboardingContractInfo("test", "test"))
   lazy val tokenSeed5: TokenSeed = TokenSeed(id = tokenId6.toString, relationships = Relationships(Seq(relationship9, relationship10)), "checksum", OnboardingContractInfo("test", "test"))
   lazy val tokenSeed6: TokenSeed = TokenSeed(id = tokenId7.toString, relationships = Relationships(Seq(relationship11, relationship12)), "checksum", OnboardingContractInfo("test", "test"))
+  lazy val tokenSeed8: TokenSeed = TokenSeed(id = tokenId8.toString, relationships = Relationships(Seq(relationship15, relationship16)), "checksum", OnboardingContractInfo("test", "test"))
 
   lazy val token1: Token = Token.generate(tokenSeed1, Seq(partyRelationship1, partyRelationship2),timestampValid).toOption.get
   lazy val token2: Token = Token.generate(tokenSeed2, Seq(partyRelationship3, partyRelationship4),timestampValid).toOption.get
@@ -230,6 +273,7 @@ object TokenApiServiceData {
   lazy val token4: Token = Token.generate(tokenSeed4, Seq(partyRelationship7, partyRelationship8),timestampValid).toOption.get
   lazy val token5: Token = Token.generate(tokenSeed5, Seq(partyRelationship9, partyRelationship10),timestampValid).toOption.get
   lazy val token6: Token = Token.generate(tokenSeed6, Seq(partyRelationship11, partyRelationship12),timestampValid).toOption.get
+  lazy val token8: Token = Token.generate(tokenSeed8, Seq(partyRelationship15, partyRelationship16),timestampValid).toOption.get
 
   // format: on
 
@@ -274,4 +318,61 @@ object TokenApiServiceData {
 
   }
 
+  lazy final val expected2 = Institution(
+    id = orgId2,
+    externalId = externalId2,
+    originId = originId2,
+    description = "Institutions Ten",
+    digitalAddress = "mail10@mail.org",
+    address = "address2",
+    zipCode = "zipCode2",
+    taxCode = "taxCode",
+    attributes = Seq.empty,
+    origin = "IPA",
+    // override from relationshipSeed3
+    institutionType = Option("OVERRIDE_institutionType"),
+    products = Map(
+      "p1" -> InstitutionProduct(
+        product = "p1",
+        pricingPlan = Option("OVERRIDE_pricingPlan"),
+        billing = Billing(
+          vatNumber = "OVERRIDE_vatNumber",
+          recipientCode = "OVERRIDE_recipientCode",
+          publicServices = Option(true)
+        )
+      )
+    )
+  )
+
+  lazy final val expected8 = Institution(
+    id = orgId8,
+    externalId = externalId8,
+    originId = originId8,
+    attributes = Seq.empty,
+    origin = "DUMMY",
+
+    // override from relationshipSeed3
+    institutionType = Option("OVERRIDE_institutionType"),
+    description = "OVERRIDE_description",
+    digitalAddress = "OVERRIDE_digitalAddress",
+    address = "OVERRIDE_address",
+    zipCode = "OVERRIDE_zipCode",
+    taxCode = "OVERRIDE_taxCode",
+    products = Map(
+      "p1" -> InstitutionProduct(
+        product = "p1",
+        pricingPlan = Option("OVERRIDE_pricingPlan"),
+        billing = Billing(
+          vatNumber = "OVERRIDE_vatNumber",
+          recipientCode = "OVERRIDE_recipientCode",
+          publicServices = Option(true)
+        )
+      ),
+      "p2" -> InstitutionProduct(
+        product = "p2",
+        pricingPlan = Option("pricingPlan2"),
+        billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(false))
+      )
+    )
+  )
 }

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/ProtobufConversionSpecs.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/ProtobufConversionSpecs.scala
@@ -6,7 +6,6 @@ import it.pagopa.interop.partymanagement.model.party._
 import it.pagopa.interop.partymanagement.model.persistence.{
   AttributesAdded,
   PartyAdded,
-  PartyUpdated,
   PartyDeleted,
   PartyRelationshipActivated,
   PartyRelationshipAdded,
@@ -14,13 +13,13 @@ import it.pagopa.interop.partymanagement.model.persistence.{
   PartyRelationshipDeleted,
   PartyRelationshipRejected,
   PartyRelationshipSuspended,
+  PartyUpdated,
   TokenAdded
 }
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1._
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.events.{
   AttributesAddedV1,
   PartyAddedV1,
-  PartyUpdatedV1,
   PartyDeletedV1,
   PartyRelationshipActivatedV1,
   PartyRelationshipAddedV1,
@@ -28,11 +27,13 @@ import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.events.
   PartyRelationshipDeletedV1,
   PartyRelationshipRejectedV1,
   PartyRelationshipSuspendedV1,
+  PartyUpdatedV1,
   TokenAddedV1
 }
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.party.{
   InstitutionAttributeV1,
   InstitutionPartyV1,
+  InstitutionProductV1,
   PartyV1,
   PersonPartyV1
 }
@@ -97,6 +98,19 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         InstitutionAttribute(origin = "origin", code = "a", description = "description_a"),
         InstitutionAttribute(origin = "origin", code = "b", description = "description_b")
       )
+      val products        = Set(
+        PersistedInstitutionProduct(
+          product = "product1",
+          pricingPlan = Option("pricingPlan"),
+          billing = PersistedBilling(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = None)
+        ),
+        PersistedInstitutionProduct(
+          product = "product1",
+          pricingPlan = Option("pricingPlan"),
+          billing =
+            PersistedBilling(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = Option(true))
+        )
+      )
 
       val partyV1: Try[InstitutionPartyV1] =
         for {
@@ -105,7 +119,7 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         } yield InstitutionPartyV1(
           id = id.toString,
           externalId = externalId,
-          originId = Option(originId),
+          originId = originId,
           description = description,
           digitalAddress = digitalAddress,
           address = address,
@@ -113,8 +127,15 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           taxCode = taxCode,
           start = start,
           end = Some(end),
-          origin = Option(origin),
+          origin = origin,
           institutionType = Option(institutionType),
+          products = products.toSeq.map(p =>
+            InstitutionProductV1(
+              product = p.product,
+              billing = BillingV1(p.billing.vatNumber, p.billing.recipientCode, p.billing.publicServices),
+              pricingPlan = p.pricingPlan
+            )
+          ),
           attributes = attributes.toSeq.map(attribute =>
             InstitutionAttributeV1(
               origin = attribute.origin,
@@ -139,6 +160,7 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         end = Some(end),
         origin = origin,
         institutionType = Option(institutionType),
+        products = products,
         attributes = attributes
       )
 
@@ -182,6 +204,18 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           InstitutionAttributeV1(origin = "origin", code = "a", description = "description_a"),
           InstitutionAttributeV1(origin = "origin", code = "b", description = "description_b")
         )
+      val products        = Seq(
+        InstitutionProductV1(
+          product = "product1",
+          pricingPlan = Option("pricingPlan"),
+          billing = BillingV1(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = None)
+        ),
+        InstitutionProductV1(
+          product = "product1",
+          pricingPlan = Option("pricingPlan"),
+          billing = BillingV1(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = Option(true))
+        )
+      )
 
       val party: InstitutionParty = InstitutionParty(
         id = id,
@@ -196,6 +230,15 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         end = Some(end),
         origin = origin,
         institutionType = Option(institutionType),
+        products = products
+          .map(p =>
+            PersistedInstitutionProduct(
+              product = p.product,
+              billing = PersistedBilling(p.billing.vatNumber, p.billing.recipientCode, p.billing.publicServices),
+              pricingPlan = p.pricingPlan
+            )
+          )
+          .toSet,
         attributes = attributes
           .map(attr => InstitutionAttribute(origin = attr.origin, code = attr.code, description = attr.description))
           .toSet
@@ -210,7 +253,7 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         } yield InstitutionPartyV1(
           id = id.toString,
           externalId = externalId,
-          originId = Option(originId),
+          originId = originId,
           description = description,
           digitalAddress = digitalAddress,
           address = address,
@@ -218,8 +261,9 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           taxCode = taxCode,
           start = start,
           end = Some(end),
-          origin = Option(origin),
+          origin = origin,
           institutionType = Option(institutionType),
+          products = products,
           attributes = attributes
         )
 

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/ProtobufConversionSpecs.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/ProtobufConversionSpecs.scala
@@ -293,6 +293,7 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           Option("DESCRIPTIONOVERRIDE"),
           Option("MAILOVERRIDE"),
           Option("ADDRESSOVERRIDE"),
+          Option("ZIPCODEOVERRIDE"),
           Option("TAXCODEOVERRIDE")
         )
       )
@@ -338,7 +339,14 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
         updatedAt = Some(u),
         pricingPlan = pricingPlan,
         institutionUpdate = institutionUpdate.map(i =>
-          PersistedInstitutionUpdate(i.institutionType, i.description, i.digitalAddress, i.address, i.taxCode)
+          PersistedInstitutionUpdate(
+            i.institutionType,
+            i.description,
+            i.digitalAddress,
+            i.address,
+            i.zipCode,
+            i.taxCode
+          )
         ),
         billing = billing.map(b => PersistedBilling(b.vatNumber, b.recipientCode, b.publicServices))
       )
@@ -369,6 +377,7 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           Option("DESCRIPTIONOVERRIDE"),
           Option("MAILOVERRIDE"),
           Option("ADDRESSOVERRIDE"),
+          Option("ZIPCODEOVERRIDE"),
           Option("TAXCODEOVERRIDE")
         )
       )
@@ -395,7 +404,14 @@ class ProtobufConversionSpecs extends AnyWordSpecLike with Matchers {
           updatedAt = Some(u),
           pricingPlan = pricingPlan,
           institutionUpdate = institutionUpdate.map(i =>
-            PersistedInstitutionUpdate(i.institutionType, i.description, i.digitalAddress, i.address, i.taxCode)
+            PersistedInstitutionUpdate(
+              i.institutionType,
+              i.description,
+              i.digitalAddress,
+              i.address,
+              i.zipCode,
+              i.taxCode
+            )
           ),
           billing = billing.map(b => PersistedBilling(b.vatNumber, b.recipientCode, b.publicServices))
         )

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
@@ -96,6 +96,7 @@ object StateCommonData {
       Option("DESCRIPTIONOVERRIDE"),
       Option("MAILOVERRIDE"),
       Option("ADDRESSOVERRIDE"),
+      Option("ZIPCODEOVERRIDE"),
       Option("TAXCODEOVERRIDE")
     )
   )

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
@@ -3,6 +3,7 @@ package it.pagopa.interop.partymanagement.persistence.v1
 import it.pagopa.interop.partymanagement.model.party.{
   InstitutionAttribute,
   PersistedBilling,
+  PersistedInstitutionProduct,
   PersistedInstitutionUpdate
 }
 
@@ -31,6 +32,19 @@ object StateCommonData {
   val attributes      = Seq(
     InstitutionAttribute(origin = "origin", code = "a", description = "description_a"),
     InstitutionAttribute(origin = "origin", code = "b", description = "description_b")
+  )
+  val products        = Set(
+    PersistedInstitutionProduct(
+      product = "product1",
+      pricingPlan = Option("pricingPlan"),
+      billing = PersistedBilling(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = None)
+    ),
+    PersistedInstitutionProduct(
+      product = "product1",
+      pricingPlan = Option("pricingPlan"),
+      billing =
+        PersistedBilling(vatNumber = "VATNUMBER", recipientCode = "RECIPIENTCODE", publicServices = Option(true))
+    )
   )
 
   val productId        = "productId"

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateData.scala
@@ -54,6 +54,7 @@ object StateData {
     end = None,
     origin = origin,
     institutionType = Option(institutionType),
+    products = products,
     attributes = attributes.toSet
   )
 

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
@@ -4,6 +4,7 @@ import it.pagopa.interop.commons.utils.TypeConversions.OffsetDateTimeOps
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.party.{
   InstitutionAttributeV1,
   InstitutionPartyV1,
+  InstitutionProductV1,
   PersonPartyV1
 }
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.relationship.{
@@ -79,7 +80,7 @@ object StateV1Data {
   val institutionPartyV1: InstitutionPartyV1 = InstitutionPartyV1(
     id = institutionPartyId.toString,
     externalId = externalId2.toString,
-    originId = Option(originId2.toString),
+    originId = originId2.toString,
     description = description,
     digitalAddress = digitalAddress,
     address = address,
@@ -87,8 +88,15 @@ object StateV1Data {
     taxCode = taxCode,
     start = start.asFormattedString.success.value,
     end = None,
-    origin = Option(origin),
+    origin = origin,
     institutionType = Option(institutionType),
+    products = products.toSeq.map(p =>
+      InstitutionProductV1(
+        product = p.product,
+        billing = BillingV1(p.billing.vatNumber, p.billing.recipientCode, p.billing.publicServices),
+        pricingPlan = p.pricingPlan
+      )
+    ),
     attributes = attributes.map(attr =>
       InstitutionAttributeV1(origin = attr.origin, code = attr.code, description = attr.description)
     )

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
@@ -41,6 +41,7 @@ object StateV1Data {
       description = i.description,
       digitalAddress = i.digitalAddress,
       address = i.address,
+      zipCode = i.zipCode,
       taxCode = i.taxCode
     )
   )


### PR DESCRIPTION
When confirming the relationship of a manager, product's billingData and pricingPlan will be stored inside the InstitutionParty

Moreover, because we plan to clear the database, we are setting as required partyRegistry fields after added in the InstitutionParty model

ps: added zipCode to InstitutionUpdate