### PR TITLE
Pinning File manager version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
     lazy val namespace = "it.pagopa"
 
     lazy val commons     = namespace %% "interop-commons-utils"        % commonsVersion
-    lazy val commonsFile = namespace %% "interop-commons-file-manager" % commonsVersion
+    lazy val commonsFile = namespace %% "interop-commons-file-manager" % "1.0.1"
     lazy val commonsJWT  = namespace %% "interop-commons-jwt"          % commonsVersion
   }
 


### PR DESCRIPTION
Azure's support will be dropped for internal reasons starting from the following file manager's stable.

This PR pins the version to the last stable. You're encouraged to fork or embed it directly in your application. As always, if you need any help, ask 👍 
