### PR TITLE
Selc 1747 geo taxonomy when onboarding

### DIFF
--- a/src/main/protobuf/v1/party.proto
+++ b/src/main/protobuf/v1/party.proto
@@ -39,6 +39,7 @@ message InstitutionPartyV1 {
   repeated InstitutionProductV1 products = 14;
   optional PaymentServiceProviderV1 paymentServiceProvider = 15;
   optional DataProtectionOfficerV1 dataProtectionOfficer = 16;
+  repeated GeographicTaxonomyV1 geographicTaxonomies = 17;
 }
 
 message InstitutionAttributeV1 {

--- a/src/main/protobuf/v1/relationship.proto
+++ b/src/main/protobuf/v1/relationship.proto
@@ -56,6 +56,7 @@ message InstitutionUpdateV1 {
   optional string taxCode = 6;
   optional PaymentServiceProviderV1 paymentServiceProvider = 7;
   optional DataProtectionOfficerV1 dataProtectionOfficer = 8;
+  repeated GeographicTaxonomyV1 geographicTaxonomies = 9;
 }
 
 message BillingV1 {
@@ -76,4 +77,9 @@ message DataProtectionOfficerV1 {
   optional string address = 1;
   optional string email = 2;
   optional string pec = 3;
+}
+
+message GeographicTaxonomyV1 {
+  required string code = 1;
+  required string desc = 2;
 }

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -979,6 +979,10 @@ components:
           $ref: '#/components/schemas/PaymentServiceProvider'
         dataProtectionOfficer:
           $ref: '#/components/schemas/DataProtectionOfficer'
+        geographicTaxonomies:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeographicTaxonomy'
       required:
         - externalId
         - originId
@@ -1040,6 +1044,10 @@ components:
           $ref: '#/components/schemas/PaymentServiceProvider'
         dataProtectionOfficer:
           $ref: '#/components/schemas/DataProtectionOfficer'
+        geographicTaxonomies:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeographicTaxonomy'
       required:
         - id
         - externalId
@@ -1052,6 +1060,7 @@ components:
         - attributes
         - origin
         - products
+        - geographicTaxonomies
       additionalProperties: false
     InstitutionId:
       type: object
@@ -1420,6 +1429,8 @@ components:
         - detail
     InstitutionUpdate:
       type: object
+      required:
+        - geographicTaxonomies
       properties:
         institutionType:
           type: string
@@ -1445,6 +1456,10 @@ components:
           $ref: '#/components/schemas/PaymentServiceProvider'
         dataProtectionOfficer:
           $ref: '#/components/schemas/DataProtectionOfficer'
+        geographicTaxonomies:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeographicTaxonomy'
     Billing:
       type: object
       properties:
@@ -1507,6 +1522,19 @@ components:
         pec:
           type: string
           description: 'Data protection officer digital address'
+    GeographicTaxonomy:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - desc
+      properties:
+        code:
+          type: string
+          description: 'Code of the geographic taxonomy'
+        desc:
+          type: string
+          description: 'Description of the geographic taxonomy code'
   securitySchemes:
     bearerAuth:
       type: http

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/PublicApiServiceImpl.scala
@@ -218,7 +218,10 @@ class PublicApiServiceImpl(
     relationship.institutionUpdate.fold(institutionParty) { institutionUpdate =>
       if (institutionParty.origin == ipaOrigin)
         institutionParty
-          .copy(institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType))
+          .copy(
+            institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
+            geographicTaxonomies = institutionUpdate.geographicTaxonomies
+          )
       else
         institutionParty.copy(
           institutionType = institutionUpdate.institutionType.orElse(institutionParty.institutionType),
@@ -226,7 +229,8 @@ class PublicApiServiceImpl(
           taxCode = institutionUpdate.taxCode.getOrElse(institutionParty.taxCode),
           description = institutionUpdate.description.getOrElse(institutionParty.description),
           digitalAddress = institutionUpdate.digitalAddress.getOrElse(institutionParty.digitalAddress),
-          zipCode = institutionUpdate.zipCode.getOrElse(institutionParty.zipCode)
+          zipCode = institutionUpdate.zipCode.getOrElse(institutionParty.zipCode),
+          geographicTaxonomies = institutionUpdate.geographicTaxonomies
         )
     }
   }

--- a/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/api/impl/package.scala
@@ -13,15 +13,16 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val paymentServiceProviderFormat: RootJsonFormat[PaymentServiceProvider] = jsonFormat5(
     PaymentServiceProvider
   )
-  implicit val institutionUpdateFormat: RootJsonFormat[InstitutionUpdate]           = jsonFormat8(InstitutionUpdate)
+  implicit val geographicTaxonomyFormat: RootJsonFormat[GeographicTaxonomy]         = jsonFormat2(GeographicTaxonomy)
+  implicit val institutionUpdateFormat: RootJsonFormat[InstitutionUpdate]           = jsonFormat9(InstitutionUpdate)
   implicit val billingFormat: RootJsonFormat[Billing]                               = jsonFormat3(Billing)
   implicit val institutionProductFormat: RootJsonFormat[InstitutionProduct]         = jsonFormat3(InstitutionProduct)
   implicit val attributeFormat: RootJsonFormat[Attribute]                           = jsonFormat3(Attribute)
   implicit val personSeedFormat: RootJsonFormat[PersonSeed]                         = jsonFormat1(PersonSeed)
   implicit val personFormat: RootJsonFormat[Person]                                 = jsonFormat1(Person)
 
-  implicit val institutionSeedFormat: RootJsonFormat[InstitutionSeed]                 = jsonFormat13(InstitutionSeed)
-  implicit val institutionFormat: RootJsonFormat[Institution]                         = jsonFormat14(Institution)
+  implicit val institutionSeedFormat: RootJsonFormat[InstitutionSeed]                 = jsonFormat14(InstitutionSeed)
+  implicit val institutionFormat: RootJsonFormat[Institution]                         = jsonFormat15(Institution)
   implicit val institutionIdFormat: RootJsonFormat[InstitutionId]                     = jsonFormat4(InstitutionId)
   implicit val institutionsFormat: RootJsonFormat[Institutions]                       = jsonFormat1(Institutions)
   implicit val relationshipProductFormat: RootJsonFormat[RelationshipProduct]         = jsonFormat3(RelationshipProduct)

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/Party.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/Party.scala
@@ -7,7 +7,7 @@ import it.pagopa.interop.partymanagement.error.PartyManagementErrors.{
   NoAttributeForPartyPerson,
   UpdateInstitutionNotFound
 }
-import it.pagopa.interop.partymanagement.model.{Attribute, Institution, InstitutionSeed, Person, PersonSeed}
+import it.pagopa.interop.partymanagement.model._
 import it.pagopa.interop.partymanagement.service.OffsetDateTimeSupplier
 
 import java.time.OffsetDateTime
@@ -77,7 +77,8 @@ object Party {
             paymentServiceProvider =
               institutionParty.paymentServiceProvider.map(p => PersistedPaymentServiceProvider.toAPi(p)),
             dataProtectionOfficer =
-              institutionParty.dataProtectionOfficer.map(d => PersistedDataProtectionOfficer.toApi(d))
+              institutionParty.dataProtectionOfficer.map(d => PersistedDataProtectionOfficer.toApi(d)),
+            geographicTaxonomies = institutionParty.geographicTaxonomies.map(PersistedGeographicTaxonomy.toApi)
           )
         )
     }
@@ -112,7 +113,8 @@ final case class InstitutionParty(
   attributes: Set[InstitutionAttribute],
   products: Set[PersistedInstitutionProduct],
   paymentServiceProvider: Option[PersistedPaymentServiceProvider],
-  dataProtectionOfficer: Option[PersistedDataProtectionOfficer]
+  dataProtectionOfficer: Option[PersistedDataProtectionOfficer],
+  geographicTaxonomies: Seq[PersistedGeographicTaxonomy]
 ) extends Party
 
 object InstitutionParty {
@@ -139,7 +141,10 @@ object InstitutionParty {
         _.values.map(PersistedInstitutionProduct.fromApi).toSet
       ),
       paymentServiceProvider = institution.paymentServiceProvider.map(PersistedPaymentServiceProvider.fromApi),
-      dataProtectionOfficer = institution.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi)
+      dataProtectionOfficer = institution.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi),
+      geographicTaxonomies = institution.geographicTaxonomies.fold(Seq.empty[PersistedGeographicTaxonomy])(
+        _.map(PersistedGeographicTaxonomy.fromApi)
+      )
     )
   }
 
@@ -162,7 +167,8 @@ object InstitutionParty {
       attributes = institution.attributes.map(InstitutionAttribute.fromApi).toSet,
       products = institution.products.values.map(PersistedInstitutionProduct.fromApi).toSet,
       paymentServiceProvider = institution.paymentServiceProvider.map(PersistedPaymentServiceProvider.fromApi),
-      dataProtectionOfficer = institution.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi)
+      dataProtectionOfficer = institution.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi),
+      geographicTaxonomies = institution.geographicTaxonomies.map(PersistedGeographicTaxonomy.fromApi)
     )
 
 }

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedGeographicTaxonomy.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedGeographicTaxonomy.scala
@@ -1,0 +1,13 @@
+package it.pagopa.interop.partymanagement.model.party
+
+import it.pagopa.interop.partymanagement.model.GeographicTaxonomy
+
+final case class PersistedGeographicTaxonomy(code: String, desc: String)
+
+object PersistedGeographicTaxonomy {
+  def toApi(geographicTaxonomy: PersistedGeographicTaxonomy): GeographicTaxonomy =
+    GeographicTaxonomy(code = geographicTaxonomy.code, desc = geographicTaxonomy.desc)
+
+  def fromApi(geographicTaxonomy: GeographicTaxonomy): PersistedGeographicTaxonomy =
+    PersistedGeographicTaxonomy(code = geographicTaxonomy.code, desc = geographicTaxonomy.desc)
+}

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionUpdate.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/party/PersistedInstitutionUpdate.scala
@@ -1,8 +1,8 @@
 package it.pagopa.interop.partymanagement.model.party
 
+import it.pagopa.interop.partymanagement.model.InstitutionUpdate
 import it.pagopa.interop.partymanagement.model.party.PersistedDataProtectionOfficer.toApi
 import it.pagopa.interop.partymanagement.model.party.PersistedPaymentServiceProvider.toAPi
-import it.pagopa.interop.partymanagement.model.{InstitutionUpdate}
 
 final case class PersistedInstitutionUpdate(
   institutionType: Option[String],
@@ -12,7 +12,8 @@ final case class PersistedInstitutionUpdate(
   zipCode: Option[String],
   taxCode: Option[String],
   paymentServiceProvider: Option[PersistedPaymentServiceProvider],
-  dataProtectionOfficer: Option[PersistedDataProtectionOfficer]
+  dataProtectionOfficer: Option[PersistedDataProtectionOfficer],
+  geographicTaxonomies: Seq[PersistedGeographicTaxonomy]
 ) {
   def toInstitutionUpdate: InstitutionUpdate = InstitutionUpdate(
     institutionType = institutionType,
@@ -21,8 +22,9 @@ final case class PersistedInstitutionUpdate(
     address = address,
     zipCode = zipCode,
     taxCode = taxCode,
-    paymentServiceProvider = paymentServiceProvider.map(toAPi(_)),
-    dataProtectionOfficer = dataProtectionOfficer.map(toApi(_))
+    paymentServiceProvider = paymentServiceProvider.map(toAPi),
+    dataProtectionOfficer = dataProtectionOfficer.map(toApi),
+    geographicTaxonomies = geographicTaxonomies.map(PersistedGeographicTaxonomy.toApi)
   )
 }
 
@@ -36,6 +38,7 @@ object PersistedInstitutionUpdate {
       zipCode = institutionUpdate.zipCode,
       taxCode = institutionUpdate.taxCode,
       paymentServiceProvider = institutionUpdate.paymentServiceProvider.map(PersistedPaymentServiceProvider.fromApi),
-      dataProtectionOfficer = institutionUpdate.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi)
+      dataProtectionOfficer = institutionUpdate.dataProtectionOfficer.map(PersistedDataProtectionOfficer.fromApi),
+      geographicTaxonomies = institutionUpdate.geographicTaxonomies.map(PersistedGeographicTaxonomy.fromApi)
     )
 }

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/PartyPersistentBehavior.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/PartyPersistentBehavior.scala
@@ -8,8 +8,6 @@ import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior, RetentionCriteria}
 import it.pagopa.interop.commons.utils.OpenapiUtils._
 import it.pagopa.interop.partymanagement.common.system.ApplicationConfiguration
-import it.pagopa.interop.partymanagement.model.party.PersistedDataProtectionOfficer.toApi
-import it.pagopa.interop.partymanagement.model.party.PersistedPaymentServiceProvider.toAPi
 import it.pagopa.interop.partymanagement.model.party._
 import it.pagopa.interop.partymanagement.model.{Institution, PartyRole, RelationshipState, TokenText}
 import it.pagopa.interop.partymanagement.service.OffsetDateTimeSupplier
@@ -116,8 +114,9 @@ object PartyPersistentBehavior {
                 institutionType = o.institutionType,
                 products = (o.products map { p => p.product -> PersistedInstitutionProduct.toApi(p) }).toMap,
                 attributes = o.attributes.map(InstitutionAttribute.toApi).toSeq,
-                paymentServiceProvider = o.paymentServiceProvider.map(toAPi(_)),
-                dataProtectionOfficer = o.dataProtectionOfficer.map(toApi(_))
+                paymentServiceProvider = o.paymentServiceProvider.map(PersistedPaymentServiceProvider.toAPi),
+                dataProtectionOfficer = o.dataProtectionOfficer.map(PersistedDataProtectionOfficer.toApi),
+                geographicTaxonomies = o.geographicTaxonomies.map(PersistedGeographicTaxonomy.toApi)
               )
           }.toList
         replyTo ! parties

--- a/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/serializer/v1/utils.scala
+++ b/src/main/scala/it/pagopa/interop/partymanagement/model/persistence/serializer/v1/utils.scala
@@ -23,7 +23,8 @@ import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.relatio
   InstitutionUpdateV1,
   PartyRelationshipProductV1,
   PartyRelationshipV1,
-  PaymentServiceProviderV1
+  PaymentServiceProviderV1,
+  GeographicTaxonomyV1
 }
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.state.{
   PartiesV1,
@@ -85,7 +86,9 @@ object utils {
               )
             ),
           dataProtectionOfficer = i.dataProtectionOfficer
-            .map(d => PersistedDataProtectionOfficer(address = d.address, email = d.email, pec = d.pec))
+            .map(d => PersistedDataProtectionOfficer(address = d.address, email = d.email, pec = d.pec)),
+          geographicTaxonomies =
+            i.geographicTaxonomies.map(x => PersistedGeographicTaxonomy(code = x.code, desc = x.desc))
         )
       }.toEither
     case Empty                 => Left(new RuntimeException("Deserialization from protobuf failed"))
@@ -136,7 +139,8 @@ object utils {
           dataProtectionOfficer = i.dataProtectionOfficer
             .map(a => DataProtectionOfficerV1(address = a.address, email = a.email, pec = a.pec)),
           start = start,
-          end = end
+          end = end,
+          geographicTaxonomies = i.geographicTaxonomies.map(x => GeographicTaxonomyV1(code = x.code, desc = x.desc))
         )
       }.toEither
   }
@@ -192,7 +196,9 @@ object utils {
           ),
           dataProtectionOfficer = i.dataProtectionOfficer.map(d =>
             PersistedDataProtectionOfficer(address = d.address, email = d.email, pec = d.pec)
-          )
+          ),
+          geographicTaxonomies =
+            i.geographicTaxonomies.map(x => PersistedGeographicTaxonomy(code = x.code, desc = x.desc))
         )
       ),
       billing = partyRelationshipV1.billing.map(getPersistedBilling)
@@ -240,7 +246,8 @@ object utils {
               )
             ),
           dataProtectionOfficer = i.dataProtectionOfficer
-            .map(d => DataProtectionOfficerV1(address = d.address, email = d.email, pec = d.pec))
+            .map(d => DataProtectionOfficerV1(address = d.address, email = d.email, pec = d.pec)),
+          geographicTaxonomies = i.geographicTaxonomies.map(x => GeographicTaxonomyV1(code = x.code, desc = x.desc))
         )
       ),
       billing = partyRelationship.billing.map(getBillingV1)

--- a/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsExternalApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsExternalApiServiceData.scala
@@ -28,7 +28,8 @@ object InstitutionsExternalApiServiceData {
     attributes = Seq.empty,
     origin = "IPA",
     institutionType = Option("PA"),
-    products = Map.empty
+    products = Map.empty,
+    geographicTaxonomies = Seq.empty
   )
 
   def prepareTest()(implicit

--- a/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsPartyApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/InstitutionsPartyApiServiceData.scala
@@ -15,6 +15,7 @@ object InstitutionsPartyApiServiceData {
   lazy final val institutionUuid2 = UUID.fromString("27f8dce0-0a5b-476b-9fdd-a7a658eb9211")
   lazy final val institutionUuid3 = UUID.fromString("27f8dce0-0a5b-476b-9fdd-a7a658eb9212")
   lazy final val institutionUuid4 = UUID.fromString("27f8dce0-0a5b-476b-9fdd-a7a658eb9213")
+  lazy final val institutionUuid5 = UUID.fromString("27f8dce0-0a5b-476b-9fdd-a7a658eb9214")
 
   lazy final val externalId1 = "ext_id1"
   lazy final val originId1   = "origin_id1"
@@ -24,6 +25,8 @@ object InstitutionsPartyApiServiceData {
   lazy final val originId3   = "origin_id3"
   lazy final val externalId4 = "ext_id4"
   lazy final val originId4   = "origin_id4"
+  lazy final val externalId5 = "ext_id5"
+  lazy final val originId5   = "origin_id5"
 
   lazy final val institutionSeed1 = InstitutionSeed(
     externalId = externalId1,
@@ -85,7 +88,8 @@ object InstitutionsPartyApiServiceData {
       ),
       attributes = Seq.empty,
       origin = "IPA",
-      institutionType = Option("PA")
+      institutionType = Option("PA"),
+      geographicTaxonomies = Option(Seq(GeographicTaxonomy(code = "GEOCODE", desc = "GEODESC")))
     )
   lazy final val institutionSeed4 =
     InstitutionSeed(
@@ -101,6 +105,34 @@ object InstitutionsPartyApiServiceData {
       origin = "IPA",
       institutionType = Option("PA")
     )
+  lazy final val institutionSeed5 =
+    InstitutionSeed(
+      externalId = externalId5,
+      originId = originId5,
+      description = "Institutions Five",
+      digitalAddress = "mail3@mail.org",
+      address = "address5",
+      zipCode = "zipCode5",
+      taxCode = "taxCode",
+      products = Option(
+        Map(
+          "p1" -> InstitutionProduct(
+            product = "p1",
+            pricingPlan = Option("pricingPlan"),
+            billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = Option(false))
+          ),
+          "p2" -> InstitutionProduct(
+            product = "p2",
+            pricingPlan = Option("pricingPlan2"),
+            billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(true))
+          )
+        )
+      ),
+      attributes = Seq.empty,
+      origin = "IPA",
+      institutionType = Option("PA"),
+      geographicTaxonomies = Option(Seq(GeographicTaxonomy(code = "GEOCODE", desc = "GEODESC")))
+    )
 
   lazy final val expected1 = Institution(
     externalId = externalId1,
@@ -114,7 +146,8 @@ object InstitutionsPartyApiServiceData {
     attributes = Seq.empty,
     origin = "IPA",
     institutionType = Option("PA"),
-    products = Map.empty
+    products = Map.empty,
+    geographicTaxonomies = Seq.empty
   )
 
   lazy final val expected3 = Institution(
@@ -140,7 +173,35 @@ object InstitutionsPartyApiServiceData {
         pricingPlan = Option("pricingPlan2"),
         billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(true))
       )
-    )
+    ),
+    geographicTaxonomies = Seq(GeographicTaxonomy(code = "GEOCODE", desc = "GEODESC"))
+  )
+
+  lazy final val expected5 = Institution(
+    externalId = externalId5,
+    originId = originId5,
+    description = "Institutions Five",
+    digitalAddress = "mail3@mail.org",
+    address = "address5",
+    zipCode = "zipCode5",
+    taxCode = "taxCode",
+    id = institutionUuid5,
+    attributes = Seq.empty,
+    origin = "IPA",
+    institutionType = Option("PA"),
+    products = Map(
+      "p1" -> InstitutionProduct(
+        product = "p1",
+        pricingPlan = Option("pricingPlan"),
+        billing = Billing(vatNumber = "vatNumber", recipientCode = "recipientCode", publicServices = Option(false))
+      ),
+      "p2" -> InstitutionProduct(
+        product = "p2",
+        pricingPlan = Option("pricingPlan2"),
+        billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(true))
+      )
+    ),
+    geographicTaxonomies = Seq(GeographicTaxonomy(code = "GEOCODE", desc = "GEODESC"))
   )
 
   def prepareTest(

--- a/src/test/scala/it/pagopa/interop/partymanagement/PartyApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/PartyApiServiceSpec.scala
@@ -281,6 +281,22 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
 
     }
 
+    "create a new institution with geographic taxonomies" in {
+
+      (() => uuidSupplier.get).expects().returning(institutionUuid5).once()
+
+      (() => offsetDateTimeSupplier.get).expects().returning(timestampValid).once()
+
+      val response = prepareTest(institutionSeed5)
+
+      val body = Unmarshal(response.entity).to[Institution].futureValue
+
+      response.status shouldBe StatusCodes.Created
+
+      body shouldBe expected5
+
+    }
+
     "return 200 if the institution exists" in {
 
       (() => uuidSupplier.get).expects().returning(institutionUuid2).once()
@@ -499,7 +515,8 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
               Option("DESCRIPTIONOVERRIDE"),
               Option("MAILOVERRIDE"),
               Option("ADDRESSOVERRIDE"),
-              Option("TAXCODEOVERRIDE")
+              Option("TAXCODEOVERRIDE"),
+              geographicTaxonomies = Seq(GeographicTaxonomy(code = "OVERRIDE_GEOCODE", desc = "OVERRIDE_GEODESC"))
             )
           )
         )
@@ -552,7 +569,8 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
               Option("DESCRIPTIONOVERRIDE"),
               Option("MAILOVERRIDE"),
               Option("ADDRESSOVERRIDE"),
-              Option("TAXCODEOVERRIDE")
+              Option("TAXCODEOVERRIDE"),
+              geographicTaxonomies = Seq(GeographicTaxonomy(code = "OVERRIDE_GEOCODE", desc = "OVERRIDE_GEODESC"))
             )
           )
         )
@@ -579,7 +597,8 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
                 Option("DESCRIPTIONOVERRIDE"),
                 Option("MAILOVERRIDE"),
                 Option("ADDRESSOVERRIDE"),
-                Option("TAXCODEOVERRIDE")
+                Option("TAXCODEOVERRIDE"),
+                geographicTaxonomies = Seq(GeographicTaxonomy(code = "OVERRIDE_GEOCODE", desc = "OVERRIDE_GEODESC"))
               )
             )
           )
@@ -1882,7 +1901,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
       body shouldBe expectedInstitution
     }
 
-    "consume a token for IPA institution" in {
+    "consume a token for IPA institution and overriding with geographic taxonomies" in {
       consumeToken(
         orgId2,
         institutionSeed2,
@@ -1896,7 +1915,7 @@ class PartyApiServiceSpec extends ScalaTestWithActorTestKit(PartyApiServiceSpec.
       )
     }
 
-    "consume a token for NON IPA institution having products already configured" in {
+    "consume a token for NON IPA institution having products already configured and overriding with no geographic taxonomies" in {
       consumeToken(
         orgId8,
         institutionSeed8,

--- a/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/TokenApiServiceData.scala
@@ -202,7 +202,8 @@ object TokenApiServiceData {
       )
     ),
     origin = "DUMMY",
-    institutionType = None
+    institutionType = None,
+    geographicTaxonomies = Some(Seq(GeographicTaxonomy(code = "GEOCODE", desc = "GEODESC")))
   )
   lazy final val institutionSeed9  = InstitutionSeed(
     externalId = externalId9,
@@ -248,7 +249,7 @@ object TokenApiServiceData {
   lazy final val relationshipSeed2 = RelationshipSeed(from = personId1, to = orgId1, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed1 = RelationshipSeed(from = personId1, to = orgId1, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed3 = RelationshipSeed(from = personId2, to = orgId2, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"),
-    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"))),
+    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"), geographicTaxonomies = Seq(GeographicTaxonomy(code = "OVERRIDE_GEOCODE", desc = "OVERRIDE_GEODESC")))),
     pricingPlan = Option("OVERRIDE_pricingPlan"), billing = Option(Billing(vatNumber="OVERRIDE_vatNumber", recipientCode="OVERRIDE_recipientCode", publicServices=Option(true))))
   lazy final val relationshipSeed4 = RelationshipSeed(from = personId2, to = orgId2, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed5 = RelationshipSeed(from = personId3, to = orgId3, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
@@ -262,7 +263,7 @@ object TokenApiServiceData {
   lazy final val relationshipSeed13 = RelationshipSeed(from = personId7, to = orgId7, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed14 = RelationshipSeed(from = personId7, to = orgId7, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed15 = RelationshipSeed(from = personId2, to = orgId8, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"),
-    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"))),
+    institutionUpdate = Option(InstitutionUpdate(institutionType=Option("OVERRIDE_institutionType"),description=Option("OVERRIDE_description"), digitalAddress=Option("OVERRIDE_digitalAddress"), address=Option("OVERRIDE_address"), zipCode=Option("OVERRIDE_zipCode"), taxCode=Option("OVERRIDE_taxCode"), geographicTaxonomies = Seq.empty)),
     pricingPlan = Option("OVERRIDE_pricingPlan"), billing = Option(Billing(vatNumber="OVERRIDE_vatNumber", recipientCode="OVERRIDE_recipientCode", publicServices=Option(true))))
   lazy final val relationshipSeed16 = RelationshipSeed(from = personId2, to = orgId8, role = PartyRole.DELEGATE, product = RelationshipProductSeed(id = "p1", role ="admin"))
   lazy final val relationshipSeed17 = RelationshipSeed(from = personId8, to = orgId9, role = PartyRole.MANAGER,  product = RelationshipProductSeed(id = "p1", role ="admin"))
@@ -407,7 +408,8 @@ object TokenApiServiceData {
           publicServices = Option(true)
         )
       )
-    )
+    ),
+    geographicTaxonomies = Seq(GeographicTaxonomy(code = "OVERRIDE_GEOCODE", desc = "OVERRIDE_GEODESC"))
   )
 
   lazy final val expected8 = Institution(
@@ -439,6 +441,7 @@ object TokenApiServiceData {
         pricingPlan = Option("pricingPlan2"),
         billing = Billing(vatNumber = "vatNumber2", recipientCode = "recipientCode2", publicServices = Option(false))
       )
-    )
+    ),
+    geographicTaxonomies = Seq.empty
   )
 }

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateCommonData.scala
@@ -5,6 +5,7 @@ import it.pagopa.interop.partymanagement.model.party.{
   InstitutionAttribute,
   PersistedBilling,
   PersistedDataProtectionOfficer,
+  PersistedGeographicTaxonomy,
   PersistedInstitutionProduct,
   PersistedInstitutionUpdate,
   PersistedPaymentServiceProvider
@@ -58,6 +59,10 @@ object StateCommonData {
   )
   val dataProtectionOfficer  =
     DataProtectionOfficer(address = Some("via Roma 1"), email = Some("ciao@ciao.it"), pec = Some("pec@pec.it"))
+  val geographicTaxonomies   = Seq(
+    PersistedGeographicTaxonomy(code = "GEOCODE1", desc = "GEODESC1"),
+    PersistedGeographicTaxonomy(code = "GEOCODE2", desc = "GEODESC2")
+  )
 
   val productId        = "productId"
   val productRole      = "productRole"
@@ -125,7 +130,8 @@ object StateCommonData {
           email = dataProtectionOfficer.email,
           pec = dataProtectionOfficer.pec
         )
-      )
+      ),
+      geographicTaxonomies = geographicTaxonomies
     )
   )
 

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateData.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateData.scala
@@ -71,7 +71,8 @@ object StateData {
         email = dataProtectionOfficer.email,
         pec = dataProtectionOfficer.pec
       )
-    )
+    ),
+    geographicTaxonomies = geographicTaxonomies
   )
 
   val relationship: PersistedPartyRelationship =

--- a/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
+++ b/src/test/scala/it/pagopa/interop/partymanagement/persistence/v1/StateV1Data.scala
@@ -7,14 +7,7 @@ import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.party.{
   InstitutionProductV1,
   PersonPartyV1
 }
-import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.relationship.{
-  BillingV1,
-  DataProtectionOfficerV1,
-  InstitutionUpdateV1,
-  PartyRelationshipProductV1,
-  PartyRelationshipV1,
-  PaymentServiceProviderV1
-}
+import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.relationship._
 import it.pagopa.interop.partymanagement.model.persistence.serializer.v1.state.{
   PartiesV1,
   RelationshipEntryV1,
@@ -60,7 +53,8 @@ object StateV1Data {
           email = dataProtectionOfficer.email,
           pec = dataProtectionOfficer.pec
         )
-      )
+      ),
+      geographicTaxonomies = geographicTaxonomies.map(x => GeographicTaxonomyV1(code = x.code, desc = x.desc))
     )
   )
 
@@ -134,7 +128,8 @@ object StateV1Data {
         email = dataProtectionOfficer.email,
         pec = dataProtectionOfficer.pec
       )
-    )
+    ),
+    geographicTaxonomies = geographicTaxonomies.map(x => GeographicTaxonomyV1(code = x.code, desc = x.desc))
   )
 
   val relationshipV1: PartyRelationshipV1 =


### PR DESCRIPTION
SELC-1747 added geographic taxonomies when onboarding, written into institution entity once the contract is signed